### PR TITLE
Resolve warnings

### DIFF
--- a/citeproc.cabal
+++ b/citeproc.cabal
@@ -25,9 +25,9 @@ extra-source-files:  stack.yaml
                      test/csl/*.txt
                      test/extra/*.txt
                      test/overrides/*.txt
-tested-with:         GHC == 8.2.2, GHC == 8.4.4,
-                     GHC == 8.6.5, GHC == 8.8.1,
-                     GHC == 8.10.1
+tested-with:         GHC == 8.0.2, GHC == 8.2.2,
+                     GHC == 8.4.4, GHC == 8.6.5,
+                     GHC == 8.8.3, GHC == 8.10.1
 
 source-repository    head
   type:              git

--- a/citeproc.cabal
+++ b/citeproc.cabal
@@ -97,6 +97,10 @@ library
                        -Werror=missing-home-modules
                        -fhide-source-paths
 
+  if impl(ghc < 8.8)
+    build-depends:       base-compat          >= 0.10
+    hs-source-dirs:      prelude
+    other-modules:       Prelude
 
   default-language:    Haskell2010
 

--- a/prelude/Prelude.hs
+++ b/prelude/Prelude.hs
@@ -1,0 +1,8 @@
+module Prelude (
+    module Prelude.Compat
+  , Semigroup (..)
+)
+where
+
+import Prelude.Compat
+import Data.Semigroup (Semigroup ((<>)))

--- a/src/Citeproc.hs
+++ b/src/Citeproc.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Process citations using the formatting instructions encoded
 -- in a CSL stylesheet.  The library targets version 1.0.1 of the

--- a/src/Citeproc.hs
+++ b/src/Citeproc.hs
@@ -10,7 +10,6 @@ module Citeproc
        , citeproc
        , Result(..)
        ) where
-import Data.Semigroup
 import qualified Data.Text as T
 import qualified Data.Set as Set
 import Citeproc.Types

--- a/src/Citeproc/CaseTransform.hs
+++ b/src/Citeproc/CaseTransform.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Provides functions that facilitate defining textcase transformations.

--- a/src/Citeproc/CaseTransform.hs
+++ b/src/Citeproc/CaseTransform.hs
@@ -18,7 +18,6 @@ module Citeproc.CaseTransform
 where
 
 import Data.Ord ()
-import Data.Semigroup
 import Data.Char (isUpper, isLower, isAscii)
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Citeproc/CslJson.hs
+++ b/src/Citeproc/CslJson.hs
@@ -34,7 +34,6 @@ where
 import Citeproc.Types
 import Citeproc.CaseTransform
 import Data.Ord ()
-import Data.Semigroup
 import Data.Char (isAlphaNum, isSpace, isAscii)
 import Data.Text (Text)
 import Data.Maybe (fromMaybe)

--- a/src/Citeproc/CslJson.hs
+++ b/src/Citeproc/CslJson.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
 -- | CSL JSON is the structured text format defined in
 -- <https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html>.

--- a/src/Citeproc/Data.hs
+++ b/src/Citeproc/Data.hs
@@ -2,9 +2,8 @@
 module Citeproc.Data
   (localeFiles)
 where
-import System.FilePath (FilePath)
 import Data.ByteString (ByteString)
-import           Data.FileEmbed
+import Data.FileEmbed
 
 localeFiles :: [(FilePath, ByteString)]
 localeFiles = $(embedDir "locales")

--- a/src/Citeproc/Element.hs
+++ b/src/Citeproc/Element.hs
@@ -17,7 +17,6 @@ module Citeproc.Element
   )
 where
 import Citeproc.Types
-import Data.Semigroup
 import Data.Maybe (fromMaybe)
 import Control.Monad (foldM)
 import qualified Data.Map as M
@@ -27,8 +26,6 @@ import qualified Data.Text as T
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Class (lift)
-
-import Debug.Trace
 
 newtype Attributes = Attributes (M.Map Text Text)
   deriving (Show, Semigroup, Monoid, Eq)

--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -10,7 +10,6 @@ where
 import Citeproc.Types
 import Citeproc.Style (mergeLocales)
 import qualified Citeproc.Unicode as Unicode
-import Data.Semigroup
 import Control.Monad.Trans.RWS.CPS
 import Data.Containers.ListUtils (nubOrdOn, nubOrd)
 import Safe (headMay, headDef, lastMay, initSafe, tailSafe, maximumMay)

--- a/src/Citeproc/Style.hs
+++ b/src/Citeproc/Style.hs
@@ -15,13 +15,10 @@ import Control.Applicative ((<|>))
 import qualified Text.XML as X
 import qualified Data.Text as T
 import qualified Data.Map as M
-import Data.Semigroup
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Default (def)
 import qualified Data.Text.Lazy as TL
 import Control.Monad.Trans.Reader (local)
-
-import Debug.Trace
 
 -- | Merge the locale specified by the first parameter, if any,
 -- with the default locale of the style and locale definitions

--- a/src/Citeproc/Types.hs
+++ b/src/Citeproc/Types.hs
@@ -108,7 +108,6 @@ import qualified Data.Map as M
 import qualified Data.Text.Read as TR
 import qualified Data.Scientific as S
 import qualified Data.CaseInsensitive as CI
-import Data.Semigroup
 import Control.Monad (foldM, guard, mzero)
 import Control.Applicative ((<|>))
 import Data.Char (isLower, isDigit, isLetter, isSpace)

--- a/src/Citeproc/Types.hs
+++ b/src/Citeproc/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/Citeproc/Unicode.hs
+++ b/src/Citeproc/Unicode.hs
@@ -17,7 +17,6 @@ import qualified Data.RFC5051 as RFC5051
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Aeson (FromJSON (..), ToJSON (..))
-import Data.Semigroup
 
 -- | A parsed IETF language tag, with language and optional variant.
 -- For example, @Lang "en" (Just "US")@ corresponds to @en-US@.


### PR DESCRIPTION
This adds a simple custom prelude for GHC versions below 8.8 to iron out differences in base.