### PR TITLE
CI: fix flag for icu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         stack: ["2.3.1"]
         ghc: ["8.8.3"]
-        stackopts: ["--flag +icu", ""]
+        stackopts: ["--flag citeproc:icu", ""]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes the CI error:
`option --flag: Must have a colon`