### PR TITLE
Support hyperlinked titles according to draft of CSL v1.0.2 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-newstyle/
 .stack-work
 stack.yaml.lock
 cabal.project.local
+.hie/

--- a/README.md
+++ b/README.md
@@ -40,8 +40,17 @@ integrated citation support and bibliography format conversion
 The main point of entry is the function `citeproc` from the
 module `Citeproc`.  This takes as arguments:
 
-- a `CiteprocOptions` structure (which currently just allows you
-  to set whether citations are hyperlinked to the bibliography)
+- a `CiteprocOptions` structure, which includes the following options:
+
+  * `linkCitations` controls whether citations are hyperlinked 
+     to the bibliography.
+
+  * `linkBibliography` automatically linkifies any identifiers (DOI, 
+     PMCID, PMID, or URL) appearing in a bibliography entry.  When
+     an entry has a DOI, PMCID, PMID, or URL available (in order of 
+     priority) but the style does not explicitly render at least one
+     of them, adds a hyperlink to the title instead.  If there is no
+     title, wraps the entire entry in a hyperlink.
 
 - a `Style`, which you will want to produce by parsing a CSL
   style file using `parseStyle` from `Citeproc.Style`.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ module `Citeproc`.  This takes as arguments:
      to the bibliography.
 
   * `linkBibliography` automatically linkifies any identifiers (DOI, 
-     PMCID, PMID, or URL) appearing in a bibliography entry.  When
-     an entry has a DOI, PMCID, PMID, or URL available (in order of 
-     priority) but the style does not explicitly render at least one
-     of them, adds a hyperlink to the title instead.  If there is no
-     title, wraps the entire entry in a hyperlink.
+     PMCID, PMID, or URL) appearing in a bibliography entry.  When an
+     entry has a DOI, PMCID, PMID, or URL available but none of these
+     are rendered by the style, add a link to the title (or, if no title
+     is present, the whole entry), using the URL for the DOI, PMCID, 
+     PMID, or URL (in that order of priority).  See
+     [Appendix VI](https://github.com/citation-style-language/documentation/blob/master/specification.rst#appendix-vi-links)
+     of the CSL v1.0.2 spec.
+
 
 - a `Style`, which you will want to produce by parsing a CSL
   style file using `parseStyle` from `Citeproc.Style`.

--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -1156,7 +1156,7 @@ evalItem layout (position, item) = do
 
              -- find identifiers that can be used to hyperlink the title 
              let mbident = 
-                    foldl (<|>) Nothing
+                    foldl' (<|>) Nothing
                       [ IdentDOI   <$> (valToText =<< lookupVariable "DOI" ref)
                       , IdentPMCID <$> (valToText =<< lookupVariable "PMCID" ref)
                       , IdentPMID  <$> (valToText =<< lookupVariable "PMID" ref)
@@ -1179,13 +1179,11 @@ evalItem layout (position, item) = do
              -- when no links were rendered for a bibliography item, hyperlink
              -- the title, if it exists, otherwise hyperlink the whole item
              let xs' =
-                   if not inBiblio
+                   if usedLink || not inBiblio
                      then xs
                    else case mburl of
                          Nothing  -> xs
-                         Just url -> if usedLink
-                                        then xs
-                                     else if usedTitle
+                         Just url -> if usedTitle
                                         -- hyperlink the title
                                         then fmap (transform (linkTitle url)) xs
                                         -- hyperlink the entire bib item

--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -1175,7 +1175,7 @@ evalItem layout (position, item) = do
                                  | checkPrefix f u ys = Linked lt u [Formatted f ys]
                  fixLinkPrefixes y = y
                  checkPrefix f url ys =
-                    let anchor = mconcat mempty (map outputToText ys)
+                    let anchor = mconcat (map outputToText ys)
                         prefix = fromMaybe "" (formatPrefix f)
                      in url == prefix <> anchor
              

--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -1156,7 +1156,7 @@ evalItem layout (position, item) = do
 
              -- find identifiers that can be used to hyperlink the title 
              let mbident = 
-                    foldl' (<|>) Nothing
+                    foldl (<|>) Nothing
                       [ IdentDOI   <$> (valToText =<< lookupVariable "DOI" ref)
                       , IdentPMCID <$> (valToText =<< lookupVariable "PMCID" ref)
                       , IdentPMID  <$> (valToText =<< lookupVariable "PMID" ref)

--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -1170,7 +1170,7 @@ evalItem layout (position, item) = do
              
             -- ensure correct handling of link prefixes like (https://doi.org/)
             -- when a link's prefix+anchor=target, ensure the link includes the prefix
-            -- (see pandoc#6723 and citeproc#88; also pandoc's fixLinks function)
+            -- (see pandoc#6723 and citeproc#88)
              let fixLinkPrefixes (Formatted f [Linked lt u ys]) 
                                  | checkPrefix f u ys = Linked lt u [Formatted f ys]
                  fixLinkPrefixes y = y

--- a/src/Citeproc/Types.hs
+++ b/src/Citeproc/Types.hs
@@ -91,6 +91,7 @@ module Citeproc.Types
   , Output(..)
   , Identifier(..)
   , identifierToURL
+  , fixShortDOI
   , LinkType(..)
   , Tag(..)
   , outputToText
@@ -1489,12 +1490,15 @@ identifierToURL ident =
       IdentPMID t  -> tolink "https://www.ncbi.nlm.nih.gov/pubmed/" t
       IdentURL t   -> tolink "https://" t
     where
-        fixShortDOI x = if "10/" `T.isPrefixOf` x
-                           then T.drop 3 x -- see https://shortdoi.org
-                           else x
         tolink pref x = if T.null x || ("://" `T.isInfixOf` x)
                            then x
                            else pref <> x
+
+-- see https://shortdoi.org
+fixShortDOI :: Text -> Text
+fixShortDOI x = if "10/" `T.isPrefixOf` x
+                   then T.drop 3 x
+                   else x
 
 data Tag =
       TagTerm

--- a/test/extra/link_bibitems.txt
+++ b/test/extra/link_bibitems.txt
@@ -1,0 +1,173 @@
+This test checks the following properties:
+  - when no DOI/PMCID/PMID/URL, in order of priority, appears as plain text in 
+      an item, and when further, no title appears, the entire bibitem should be
+      linkified with one of those identifiers.
+  - shortDOIs should be handled correctly, meaning that every shortDOI of
+      the form 10/abcde should be converted to the DOI abcde
+
+>>===== MODE =====>>
+bibliography
+<<===== MODE =====<<
+
+>>===== RESULT =====>>
+<div class="csl-bib-body">
+  <div class="csl-entry"><a href="https://doi.org/10.1021/ja01577a030">Apple. 2010</a></div>
+  <div class="csl-entry"><a href="https://doi.org/bbbbb">Blueberry. 2011</a></div>
+  <div class="csl-entry"><a href="https://pandoc.org/">Cherry. 2012</a></div>
+  <div class="csl-entry"><a href="https://www.ncbi.nlm.nih.gov/pubmed/30310042">Durian. 2013</a></div>
+  <div class="csl-entry"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531190">Elderberry. 2014</a></div>
+  <div class="csl-entry"><a href="https://doi.org/bbbbb">Fig. 2015</a></div>
+  <div class="csl-entry"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531190">Grapefruit. 2016</a></div>
+  <div class="csl-entry"><a href="https://www.ncbi.nlm.nih.gov/pubmed/30310042">Honeydew. 2017</a></div>
+</div>
+<<===== RESULT =====<<
+
+>>===== CSL =====>>
+<?xml version="1.0" encoding="utf-8"?>
+<style 
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2009-08-10T04:49:00+09:00</updated>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name form="short" />
+    </names>
+  </macro>
+  <citation>
+    <layout delimiter="; ">
+      <text macro="author" />
+      <date variable="issued" prefix=" ">
+        <date-part name="year"/>
+      </date>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="author" />
+    </sort>
+    <layout delimiter=". ">
+      <text macro="author" />
+      <date variable="issued" prefix=". ">
+        <date-part name="year"/>
+      </date>
+    </layout>
+  </bibliography>
+</style>
+<<===== CSL =====<<
+
+>>===== INPUT =====>>
+[
+    {
+        "author": [
+            { "family": "Apple", "given": "Andrew" }
+        ],
+        "id": "ITEM-A",
+        "type": "book",
+        "title": "AAAA",
+        "DOI": "10.1021/ja01577a030",
+        "issued": {
+          "date-parts": [ [ 2010 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Blueberry", "given": "Bethany" }
+        ],
+        "id": "ITEM-B",
+        "type": "book",
+        "title": "BBBB",
+        "DOI": "10/bbbbb",
+        "issued": {
+          "date-parts": [ [ 2011 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Cherry", "given": "Carlos" }
+        ],
+        "id": "ITEM-C",
+        "type": "book",
+        "title": "CCCC",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2012 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Durian", "given": "Denice" }
+        ],
+        "id": "ITEM-D",
+        "type": "book",
+        "title": "DDDD",
+        "PMID": "30310042",
+        "issued": {
+          "date-parts": [ [ 2013 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Elderberry", "given": "Edward" }
+        ],
+        "id": "ITEM-E",
+        "type": "book",
+        "title": "EEEE",
+        "PMCID": "PMC3531190",
+        "issued": {
+          "date-parts": [ [ 2014 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Fig", "given": "Francella" }
+        ],
+        "id": "ITEM-F",
+        "type": "book",
+        "title": "FFFF",
+        "DOI": "10/bbbbb",
+        "PMCID": "PMC3531190",
+        "PMID": "30310042",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2015 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Grapefruit", "given": "Gordon" }
+        ],
+        "id": "ITEM-G",
+        "type": "book",
+        "title": "GGGG",
+        "PMCID": "PMC3531190",
+        "PMID": "30310042",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2016 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Honeydew", "given": "Helen" }
+        ],
+        "id": "ITEM-H",
+        "type": "book",
+        "title": "HHHH",
+        "PMID": "30310042",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2017 ] ]
+        }
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/test/extra/link_bibitems.txt
+++ b/test/extra/link_bibitems.txt
@@ -9,6 +9,12 @@ This test checks the following properties:
 bibliography
 <<===== MODE =====<<
 
+>>===== OPTIONS =====>>
+{
+  "linkBibliography" : true
+}
+<<===== OPTIONS =====<<
+
 >>===== RESULT =====>>
 <div class="csl-bib-body">
   <div class="csl-entry"><a href="https://doi.org/10.1021/ja01577a030">Apple. 2010</a></div>

--- a/test/extra/link_plainurls.txt
+++ b/test/extra/link_plainurls.txt
@@ -1,0 +1,146 @@
+This test checks the following properties:
+  - plain URLs appearing in bibliography items should be linkified
+  - when a link's prefix+anchor matches its target, the
+      prefix should be included in the anchor
+  - shortDOIs should be handled correctly, meaning that every shortDOI of
+      the form 10/abcde should be converted to the DOI abcde
+
+>>===== MODE =====>>
+bibliography
+<<===== MODE =====<<
+
+>>===== RESULT =====>>
+<div class="csl-bib-body">
+  <div class="csl-entry">Apple. AAAA. 2010. <a href="https://doi.org/10.1021/ja01577a030">https://doi.org/10.1021/ja01577a030</a></div>
+  <div class="csl-entry">Blueberry. BBBB. 2011. <a href="https://doi.org/bbbbb">https://doi.org/bbbbb</a></div>
+  <div class="csl-entry">Cherry. CCCC. 2012. <a href="https://pandoc.org/">https://pandoc.org/</a></div>
+  <div class="csl-entry">Durian. DDDD. 2013. <a href="https://www.ncbi.nlm.nih.gov/pubmed/30310042">https://www.ncbi.nlm.nih.gov/pubmed/30310042</a></div>
+  <div class="csl-entry">Elderberry. EEEE. 2014. <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531190">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531190</a></div>
+</div>
+<<===== RESULT =====<<
+
+>>===== CSL =====>>
+<?xml version="1.0" encoding="utf-8"?>
+<style 
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2009-08-10T04:49:00+09:00</updated>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name form="short" />
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="PMCID">
+        <text variable="PMCID" prefix="https://www.ncbi.nlm.nih.gov/pmc/articles/"/>
+      </else-if>
+      <else-if variable="PMID">
+        <text variable="PMID" prefix="https://www.ncbi.nlm.nih.gov/pubmed/"/>
+      </else-if>
+      <else>
+        <text variable="URL"/>
+      </else>
+    </choose>
+  </macro>
+  <citation>
+    <layout delimiter="; ">
+      <text macro="author" />
+      <date variable="issued" prefix=" ">
+        <date-part name="year"/>
+      </date>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="author" />
+    </sort>
+    <layout delimiter=". ">
+      <text macro="author" />
+      <text variable="title" text-case="title" prefix=". "/>
+      <date variable="issued" prefix=". ">
+        <date-part name="year"/>
+      </date>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>
+<<===== CSL =====<<
+
+>>===== INPUT =====>>
+[
+    {
+        "author": [
+            { "family": "Apple", "given": "Andrew" }
+        ],
+        "id": "ITEM-A",
+        "type": "book",
+        "title": "AAAA",
+        "DOI": "10.1021/ja01577a030",
+        "issued": {
+          "date-parts": [ [ 2010 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Blueberry", "given": "Bethany" }
+        ],
+        "id": "ITEM-B",
+        "type": "book",
+        "title": "BBBB",
+        "DOI": "10/bbbbb",
+        "issued": {
+          "date-parts": [ [ 2011 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Cherry", "given": "Carlos" }
+        ],
+        "id": "ITEM-C",
+        "type": "book",
+        "title": "CCCC",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2012 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Durian", "given": "Denice" }
+        ],
+        "id": "ITEM-D",
+        "type": "book",
+        "title": "DDDD",
+        "PMID": "30310042",
+        "issued": {
+          "date-parts": [ [ 2013 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Elderberry", "given": "Edward" }
+        ],
+        "id": "ITEM-E",
+        "type": "book",
+        "title": "EEEE",
+        "PMCID": "PMC3531190",
+        "issued": {
+          "date-parts": [ [ 2014 ] ]
+        }
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/test/extra/link_plainurls.txt
+++ b/test/extra/link_plainurls.txt
@@ -9,6 +9,12 @@ This test checks the following properties:
 bibliography
 <<===== MODE =====<<
 
+>>===== OPTIONS =====>>
+{
+  "linkBibliography" : true
+}
+<<===== OPTIONS =====<<
+
 >>===== RESULT =====>>
 <div class="csl-bib-body">
   <div class="csl-entry">Apple. AAAA. 2010. <a href="https://doi.org/10.1021/ja01577a030">https://doi.org/10.1021/ja01577a030</a></div>

--- a/test/extra/link_titles.txt
+++ b/test/extra/link_titles.txt
@@ -8,6 +8,12 @@ This test checks the following properties:
 bibliography
 <<===== MODE =====<<
 
+>>===== OPTIONS =====>>
+{
+  "linkBibliography" : true
+}
+<<===== OPTIONS =====<<
+
 >>===== RESULT =====>>
 <div class="csl-bib-body">
   <div class="csl-entry">Apple. <a href="https://doi.org/10.1021/ja01577a030">AAAA</a>. 2010</div>

--- a/test/extra/link_titles.txt
+++ b/test/extra/link_titles.txt
@@ -1,0 +1,173 @@
+This test checks the following properties:
+  - when no DOI/PMCID/PMID/URL, in order of priority, appears as plain text in 
+      an item, the title should be linkified with one of those identifiers
+  - shortDOIs should be handled correctly, meaning that every shortDOI of
+      the form 10/abcde should be converted to the DOI abcde
+
+>>===== MODE =====>>
+bibliography
+<<===== MODE =====<<
+
+>>===== RESULT =====>>
+<div class="csl-bib-body">
+  <div class="csl-entry">Apple. <a href="https://doi.org/10.1021/ja01577a030">AAAA</a>. 2010</div>
+  <div class="csl-entry">Blueberry. <a href="https://doi.org/bbbbb">BBBB</a>. 2011</div>
+  <div class="csl-entry">Cherry. <a href="https://pandoc.org/">CCCC</a>. 2012</div>
+  <div class="csl-entry">Durian. <a href="https://www.ncbi.nlm.nih.gov/pubmed/30310042">DDDD</a>. 2013</div>
+  <div class="csl-entry">Elderberry. <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531190">EEEE</a>. 2014</div>
+  <div class="csl-entry">Fig. <a href="https://doi.org/bbbbb">FFFF</a>. 2015</div>
+  <div class="csl-entry">Grapefruit. <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3531190">GGGG</a>. 2016</div>
+  <div class="csl-entry">Honeydew. <a href="https://www.ncbi.nlm.nih.gov/pubmed/30310042">HHHH</a>. 2017</div>
+</div>
+<<===== RESULT =====<<
+
+>>===== CSL =====>>
+<?xml version="1.0" encoding="utf-8"?>
+<style 
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2009-08-10T04:49:00+09:00</updated>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name form="short" />
+    </names>
+  </macro>
+  <citation>
+    <layout delimiter="; ">
+      <text macro="author" />
+      <date variable="issued" prefix=" ">
+        <date-part name="year"/>
+      </date>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="author" />
+    </sort>
+    <layout delimiter=". ">
+      <text macro="author" />
+      <text variable="title" text-case="title" prefix=". "/>
+      <date variable="issued" prefix=". ">
+        <date-part name="year"/>
+      </date>
+    </layout>
+  </bibliography>
+</style>
+<<===== CSL =====<<
+
+>>===== INPUT =====>>
+[
+    {
+        "author": [
+            { "family": "Apple", "given": "Andrew" }
+        ],
+        "id": "ITEM-A",
+        "type": "book",
+        "title": "AAAA",
+        "DOI": "10.1021/ja01577a030",
+        "issued": {
+          "date-parts": [ [ 2010 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Blueberry", "given": "Bethany" }
+        ],
+        "id": "ITEM-B",
+        "type": "book",
+        "title": "BBBB",
+        "DOI": "10/bbbbb",
+        "issued": {
+          "date-parts": [ [ 2011 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Cherry", "given": "Carlos" }
+        ],
+        "id": "ITEM-C",
+        "type": "book",
+        "title": "CCCC",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2012 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Durian", "given": "Denice" }
+        ],
+        "id": "ITEM-D",
+        "type": "book",
+        "title": "DDDD",
+        "PMID": "30310042",
+        "issued": {
+          "date-parts": [ [ 2013 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Elderberry", "given": "Edward" }
+        ],
+        "id": "ITEM-E",
+        "type": "book",
+        "title": "EEEE",
+        "PMCID": "PMC3531190",
+        "issued": {
+          "date-parts": [ [ 2014 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Fig", "given": "Francella" }
+        ],
+        "id": "ITEM-F",
+        "type": "book",
+        "title": "FFFF",
+        "DOI": "10/bbbbb",
+        "PMCID": "PMC3531190",
+        "PMID": "30310042",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2015 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Grapefruit", "given": "Gordon" }
+        ],
+        "id": "ITEM-G",
+        "type": "book",
+        "title": "GGGG",
+        "PMCID": "PMC3531190",
+        "PMID": "30310042",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2016 ] ]
+        }
+    },
+    {
+        "author": [
+            { "family": "Honeydew", "given": "Helen" }
+        ],
+        "id": "ITEM-H",
+        "type": "book",
+        "title": "HHHH",
+        "PMID": "30310042",
+        "URL": "https://pandoc.org/",
+        "issued": {
+          "date-parts": [ [ 2017 ] ]
+        }
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
As described in #86, the working draft of the CSL v1.0.2 specification has a [recommendation for automatically linking titles](https://github.com/citation-style-language/documentation/blob/master/specification.rst#appendix-vi-links) when the citation style does not explicitly render the URL.  See also the [discussion by the CSL maintainers](https://github.com/citation-style-language/documentation/issues/76).  This draft PR adds this functionality to `citeproc` (and transitively to `pandoc`).

### Relevant Snippet from the draft CSL v1.0.2 Spec

> The CSL syntax does not have support for configuration of links. However, processors should include links on bibliographic references, using the following rules:
>
> If the bibliography entry for an item renders any of the following identifiers, the identifier should be anchored as a link, with the target of the link as follows:
>
> 1. ``url``: output as is
> 2. ``doi``: prepend with "https://doi.org/"
> 3. ``pmid``: prepend with "https://www.ncbi.nlm.nih.gov/pubmed/"
> 4. ``pmcid``: prepend with "https://www.ncbi.nlm.nih.gov/pmc/articles/"
>
> If the identifier is rendered as a URI, include rendered URI components (e.g. "https://doi.org/") in the link anchor. Do not include any other affix text in the link anchor (e.g. "Available from: ", "doi: ", "PMID: ").
> If the bibliography entry for an item does not render any of the above identifiers, then set the anchor of the link as the item ``title``. If ``title`` is not rendered, then set the anchor of the link as the full bibliography entry for the item. Set the target of the link as one of the following, in order of priority:
> 
> 1. ``doi``: prepend with "https://doi.org/"
> 2. ``pmcid``: prepend with "https://www.ncbi.nlm.nih.gov/pmc/articles/"
> 3. ``pmid``: prepend with "https://www.ncbi.nlm.nih.gov/pubmed/"
> 4. ``url``: output as is
> 
> If the item data does not include any of the above identifiers, do not include a link.
> 
> Citation processors should include an option flag for calling applications to disable bibliography linking behavior.

### Tasks / Considerations

Finishing the Feature

- [x] Currently my PR only supports hyperlinking *titles*, but the CSL spec says that the *entire* bibitem should be hyperlinked when neither a title nor explicit identifier element is present.  I see a few ways to accomplish this, **what do you think is best?**  
    * Initially, I wanted to wrap the output of `Eval.hs/evalItem` with a tag, but the `Tagged` constructor only takes a single `Output a`, instead of a list `[Output a]`.
    * (Option 1) So, one option would be to add a new `Link Identifier [Output a]` constructor to the `Output` type.
    * (Option 2) Alternatively, instead of using tags, another field called `formatLink :: Maybe Text` could be added to the `Formatting` type.  When this field is not `Nothing`, the `addFormatting` would render the link using `addHyperlink`.  However, this would require changing the `Element.hs/getFormatting` function to handle links, and I'm not sure if that makes sense.
    * **Decision:**  Chose Option 1
- [x] Currently, URLs etc are linkified in `pandoc`.  It should be straightforward to move this functionality into the `Eval.hs/eText` function.  **Should I do it?**
   * **Decision:**  Yes, move the linkify code from pandoc to citeproc
- [x] If only an ISBN is provided (but none of the other `Identifier` types) , should it be used to hyperlink the title?  This isn't in the CSL spec, but since `pandoc` already linkifies ISBNs, it would be natural to include here.
    * **Decision:**  Don't linkify ISBN anymore

Testing / Documentation

- [x] I compiled `pandoc` against my local copy of `citeproc` and everything seems to work as expected, but **further testing is needed**.
- [x] What would be a good way to **write tests** for this feature?  Currently the `citeproc` tests all use the `CslJson` data type, which [does not support hyperlinks](https://github.com/jgm/citeproc/blob/master/src/Citeproc/CslJson.hs#L150).  I suppose we could add another `CiteprocOutput` instance just for testing.
- [x] What should the **default** be for the new `linkTitles` option?
    * `False` would be more backward-compatible, but I'd argue `True` is more in line with what users might expect.  This has been a pet peeve of mine for a while (when viewing HTML output by pandoc) and it's very satisfying to finally be able to fix it :).
    * **Decision:** `linkTitles` should default to False
- [x] Update `citeproc` documentation to reflect this behavior, in particular the new `linkTitles` option.
    * What should the default for `linkTitles` be?  I think setting it to `True` in the context of the Pandoc HTML Writer would be appropriate, but I
- [x] Consider how these changes will impact `pandoc`.  Probably a change to `pandoc` will be required, at the very least to document this functionality and set a sensible default for the `linkTitles` option.

Thanks for your feedback!