### PR TITLE
Require data-default >= 0.5.2

### DIFF
--- a/citeproc.cabal
+++ b/citeproc.cabal
@@ -73,7 +73,7 @@ library
                      , uniplate
                      , xml-conduit
                      , attoparsec
-                     , data-default
+                     , data-default >= 0.5.2
                      , aeson
                      , filepath
                      , file-embed


### PR DESCRIPTION
Otherwise build fails with
```
$ cabal build --constraint 'data-default == 0.5.1'
src/Citeproc/Locale.hs:29:20: error:
    • No instance for (Data.Default.Default X.ParseSettings)
        arising from a use of ‘def’
    • In the first argument of ‘X.parseText’, namely ‘def’
      In the first argument of ‘($)’, namely ‘X.parseText def’
      In the expression: X.parseText def $ TL.fromStrict t
   |
29 |   case X.parseText def $ TL.fromStrict t of
   |                    ^^^
```