### PR TITLE
CI: use correct ghc/cabal versions from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Install cabal/ghc
       run: |
-        ghcup install ghc --set ${{ matrix.versions.ghc }}
-        ghcup install cabal --set ${{ matrix.versions.cabal }}
+        ghcup install ghc --set ${{ matrix.ghc }}
+        ghcup install cabal --set ${{ matrix.cabal }}
 
     - name: Cache cabal global package db
       id:   cabal-global


### PR DESCRIPTION
The CI uses the wrong variables to access ghc/cabal version from matrix since db05e1e. This PR fixes the references but unfortunately the build fails with the correct ghc versions.