### PR TITLE
Fix entity-escaping of characters in the executable output

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -99,7 +99,17 @@ main = do
                                    (resultBibliography result))
                           , ("warnings", Aeson.toJSON $ resultWarnings result)
                           ]
-                   Html -> Aeson.toJSON result
+                   Html -> Aeson.object
+                          [ ("citations", Aeson.toJSON $
+                               map cslJsonToHtml
+                                   (resultCitations result))
+                          , ("bibliography", Aeson.toJSON $
+                               map (second cslJsonToHtml)
+                                   (resultBibliography result))
+                          , ("warnings", Aeson.toJSON $ resultWarnings result)
+                          ]
+                          where cslJsonToHtml el =
+                                  renderCslJson True mempty el
           BL.putStr $ AesonPretty.encodePretty'
                        AesonPretty.defConfig
                          { confIndent = AesonPretty.Spaces 2


### PR DESCRIPTION
Previously a bibliography entry might render as:

```
Flatt, Matthew, ‘Binding as Sets of Scopes’, in <i>Proceedings of the 43rd Annual ACM SIGPLAN-SIGACT Symposium on Principles of Programming Languages</i>, POPL ’16 (New York, NY, USA, 2016), 705–17 <<a href="https://doi.org/10.1145/2837614.2837620">https://doi.org/10.1145/2837614.2837620</a>>
```

when output from the executable in ‘html’ output format. Note the invalid HTML `<<a href="...`.

This commit corrects the HTML generation from the command-line tool so that angle brackets and ampersands within text are properly escaped.