### PR TITLE
add Eq typeclass instance for "Result a"

### DIFF
--- a/src/Citeproc/Types.hs
+++ b/src/Citeproc/Types.hs
@@ -1724,7 +1724,7 @@ data Result a =
                     -- each a pair consisting of the item identifier and
                     -- the formatted entry
   , resultWarnings      :: [Text]       -- ^ Warnings from citation processing
-  } deriving (Show, Functor, Traversable, Foldable)
+  } deriving (Eq, Show, Functor, Traversable, Foldable)
 
 instance ToJSON a => ToJSON (Result a) where
   toJSON res = object


### PR DESCRIPTION
Adding Eq allows Citeproc library users to write tests that check one
Result with another easily. Practically speaking this commit doesn't
really change behavior, because the only way to generate a Result is by
feeding in a type that supports CiteprocOutput (and CiteprocOutput
already requires the parameterized type to have an Eq typeclass
instance).