### PR TITLE
Allow semantic markup in bibliographies (see #132)

### DIFF
--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -1655,11 +1655,11 @@ eText (TextVariable varForm v) = do
         res <- case mbv of
                  Just (TextVal x)
                    | v == "page" -> pageRange x
-                   | otherwise   -> return $ Literal $ fromText x
+                   | otherwise   -> return $ Tagged (TagNames v (NamesFormat Nothing Nothing Nothing False) []) $ Literal $ fromText x
                  Just (FancyVal x)
                    | v == "page" -> pageRange (toText x)
-                   | otherwise   -> return $ Literal x
-                 Just (NumVal x) -> return $ Literal
+                   | otherwise   -> return $ Tagged (TagNames v (NamesFormat Nothing Nothing Nothing False) []) $ Literal x
+                 Just (NumVal x) -> return $ Tagged (TagNames v (NamesFormat Nothing Nothing Nothing False) []) $ Literal
                                            $ fromText (T.pack (show x))
                  _ -> return NullOutput
         unless (isNothing mbv) $ deleteSubstitutedVariables [v]

--- a/src/Citeproc/Pandoc.hs
+++ b/src/Citeproc/Pandoc.hs
@@ -79,6 +79,7 @@ instance CiteprocOutput Inlines where
           go x       = x
   addHyperlink t        = B.link t ""
   localizeQuotes        = convertQuotes
+  addVariableClass var  = B.spanWith ("", [fromVariable var], [])
 
 -- localized quotes
 convertQuotes :: Locale -> Inlines -> Inlines

--- a/src/Citeproc/Types.hs
+++ b/src/Citeproc/Types.hs
@@ -208,6 +208,7 @@ class (Semigroup a, Monoid a, Show a, Eq a, Ord a) => CiteprocOutput a where
   mapText                     :: (Text -> Text) -> a -> a
   addHyperlink                :: Text -> a -> a
   localizeQuotes              :: Locale -> a -> a
+  addVariableClass            :: Variable -> a -> a
 
 addFormatting :: CiteprocOutput a => Formatting -> a -> a
 addFormatting f x =
@@ -1547,6 +1548,12 @@ renderOutput opts (Tagged (TagNames _ _ ns) x)
   -- capitalized in pandoc footnotes: see jgm/pandoc#10983
   | any hasNonstandardCase ns
   = addTextCase Nothing PreserveCase $ renderOutput opts x
+-- added for semantic tagging
+renderOutput opts (Tagged (TagNames var _ _) x)
+  = addVariableClass var $ renderOutput opts x
+-- added for semantic tagging of dates
+renderOutput opts (Tagged (TagDate date) x)
+  = addVariableClass "date" $ renderOutput opts x
 renderOutput opts (Tagged _ x) = renderOutput opts x
 renderOutput opts (Formatted f [Linked url xs])
   | linkBibliography opts


### PR DESCRIPTION
We worked with @marviro to add a function to `CiteprocOutput` that allows `renderOutput` to create markup that preserves metadata in bibliographies. See the relevant issues: https://github.com/jgm/citeproc/issues/132 and https://github.com/jgm/pandoc/issues/8790. We are not sure this is the proper or best way to move forward.