### PR TITLE
Detect terminal punctuation hidden by closing quotes

### DIFF
--- a/src/Citeproc/Types.hs
+++ b/src/Citeproc/Types.hs
@@ -119,7 +119,9 @@ import qualified Data.Scientific as S
 import qualified Data.CaseInsensitive as CI
 import Control.Monad (foldM, guard, mzero)
 import Control.Applicative ((<|>), optional)
-import Data.Char (isLower, isDigit, isLetter, isSpace, isAlphaNum, isAscii)
+import Data.Char (GeneralCategory(FinalQuote),
+                  generalCategory, isLower, isDigit,
+                  isLetter, isSpace, isAlphaNum, isAscii)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import qualified Data.Text as T
@@ -1693,10 +1695,30 @@ fixPunct (x:y:zs) =
  where
   xText = toText x
   yText = toText y
-  xEnd = if T.null xText then '\xFFFD' else T.last xText
-  yStart = if T.null yText then '\xFFFD' else T.head yText
+  yStart = fromMaybe '\xFFFD' (firstChar yText)
+  -- see #179
+  xEnd =
+     if yStart == '.'
+       then fromMaybe xLast (terminalCharBeforeQuote xText)
+       else xLast
+  xLast = fromMaybe '\xFFFD' (lastChar xText)
   xTrimmed = dropTextWhileEnd (== xEnd) x
   yTrimmed = dropTextWhile (== yStart) y
+  firstChar = fmap fst . T.uncons
+  lastChar = fmap snd . T.unsnoc
+  terminalCharBeforeQuote t =
+    let trimmed = T.dropWhileEnd isSpace t
+    in case T.unsnoc trimmed of
+         Just (_, q) | isQuoteLike q ->
+           lastChar (T.dropWhileEnd isTrailingCloser trimmed)
+         _ -> Nothing
+  isQuoteLike c =
+       c == '"'
+    || c == '\''
+    || generalCategory c == FinalQuote
+  isTrailingCloser c =
+       isSpace c
+    || isQuoteLike c
   keepFirst = if yTrimmed == y -- see #49
                  then x : fixPunct (y : zs)
                  else fixPunct $ x : yTrimmed : zs

--- a/test/extra/issue_179.txt
+++ b/test/extra/issue_179.txt
@@ -1,0 +1,84 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+Doe, ‘Ends with period inside quotes.’
+Doe, ‘Ends with question mark?’
+Doe, ‘Ends with an exclamation mark!’
+Doe, ‘Ends with period outside quotes’.
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", 'Ends with period inside quotes.'"
+    }
+  ],
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", 'Ends with question mark?'"
+    }
+  ],
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", 'Ends with an exclamation mark!'"
+    }
+  ],
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", 'Ends with period outside quotes'."
+    }
+  ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0"
+      default-locale="en-GB">
+  <info>
+    <id />
+    <title />
+    <updated>2026-05-03T22:24:00+00:00</updated>
+  </info>
+  <citation>
+    <layout suffix=".">
+      <names variable="author">
+        <name form="short" />
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+  {
+    "author": [
+      {
+        "family": "Doe",
+        "given": "John"
+      }
+    ],
+    "id": "ITEM-1",
+    "type": "book"
+  }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/test/extra/issue_179_enUS.txt
+++ b/test/extra/issue_179_enUS.txt
@@ -1,0 +1,77 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+Doe, “Ends with period inside quotes.”
+Doe, “Ends with question mark?”
+Doe, “Ends with an exclamation mark!”
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", \"Ends with period inside quotes.\""
+    }
+  ],
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", \"Ends with question mark?\""
+    }
+  ],
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", \"Ends with an exclamation mark!\""
+    }
+  ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0"
+      default-locale="en-US">
+  <info>
+    <id />
+    <title />
+    <updated>2026-05-03T22:24:00+00:00</updated>
+  </info>
+  <citation>
+    <layout suffix=".">
+      <names variable="author">
+        <name form="short" />
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+  {
+    "author": [
+      {
+        "family": "Doe",
+        "given": "John"
+      }
+    ],
+    "id": "ITEM-1",
+    "type": "book"
+  }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/test/extra/issue_179_paren.txt
+++ b/test/extra/issue_179_paren.txt
@@ -1,0 +1,63 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+Doe, (E.D. Wisc.).
+<<===== RESULT =====<<
+
+
+>>===== CITATION-ITEMS =====>>
+[
+  [
+    {
+      "id": "ITEM-1",
+      "suffix": ", (E.D. Wisc.)"
+    }
+  ]
+]
+<<===== CITATION-ITEMS =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0"
+      default-locale="en-US">
+  <info>
+    <id />
+    <title />
+    <updated>2026-05-03T22:24:00+00:00</updated>
+  </info>
+  <citation>
+    <layout suffix=".">
+      <names variable="author">
+        <name form="short" />
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+  {
+    "author": [
+      {
+        "family": "Doe",
+        "given": "John"
+      }
+    ],
+    "id": "ITEM-1",
+    "type": "book"
+  }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
When a suffix ends with punctuation inside a closing quote (e.g. `'text.'`), the quote hides the terminal period. Strip trailing quotes for collision detection.

Closes #179.