### PR TITLE
Apply abbreviations to literal names in short form

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ writes a JSON-encoded `Result` object to `stdout`. (It does so
 using `CslJson Text` as the underlying type.) This executable can
 be used to add citation processing to non-Haskell projects.
 
+When CSL abbreviations are provided, they are applied when a variable
+is rendered with `form="short"`.  This includes short-form rendering
+of literal names.
+
 `citeproc --help` will summarize usage information.  See
 the [man page](man/citeproc.1.md) for more information.
 

--- a/src/Citeproc/Eval.hs
+++ b/src/Citeproc/Eval.hs
@@ -2169,7 +2169,7 @@ eSubstitute els =
         [] -> eSubstitute es
         (x:_) -> return [x]
 
-formatNames :: CiteprocOutput a
+formatNames :: forall a . CiteprocOutput a
             => NamesFormat
             -> NameFormat
             -> Formatting
@@ -2177,8 +2177,13 @@ formatNames :: CiteprocOutput a
             -> Eval a (Output a)
 formatNames namesFormat nameFormat formatting (var, Just (NamesVal names)) =
   do
+  abbreviations <- asks contextAbbreviations
   isSubsequent <- (Subsequent `elem`) <$> asks contextPosition
   isInBibliography <- asks contextInBibliography
+  let abbreviateLiteralName name = fromMaybe name $ do
+        t <- nameLiteral name
+        TextVal abbr <- abbreviations >>= lookupAbbreviation var (TextVal t :: Val a)
+        return name{ nameLiteral = Just abbr }
   let (etAlMin, etAlUseFirst) =
         if not isInBibliography && isSubsequent
            then (nameEtAlSubsequentMin nameFormat <|> nameEtAlMin nameFormat,
@@ -2187,7 +2192,11 @@ formatNames namesFormat nameFormat formatting (var, Just (NamesVal names)) =
            else (nameEtAlMin nameFormat, nameEtAlUseFirst nameFormat)
   inSortKey <- asks contextInSortKey
   disamb <- gets (referenceDisambiguation . stateReference)
-  names' <- zipWithM (formatName nameFormat formatting) [1..] names
+  let namesForRendering =
+        if nameForm nameFormat == Just ShortName
+           then map abbreviateLiteralName names
+           else names
+  names' <- zipWithM (formatName nameFormat formatting) [1..] namesForRendering
   let delim' = fromMaybe ", " $
                  (formatDelimiter formatting <|> nameDelimiter nameFormat)
   let delim = case (beginsWithSpace <$> formatSuffix formatting,
@@ -2304,17 +2313,18 @@ formatNames namesFormat nameFormat formatting (var, Just (NamesVal names)) =
   let names'' = zipWith addNameAndDelim names' [1..]
   -- we set delimiter to Nothing because we're handling delim
   -- manually, to allow for things like "and" and no final comma
-  return $ Tagged (TagNames var namesFormat names)
+  return $ Tagged (TagNames var namesFormat namesForRendering)
          $ grouped $
            if namesLabelBeforeName namesFormat
               then label ++ names''
               else names'' ++ label
 
+formatNames _ _ _ (_, Nothing) = return NullOutput
+
 formatNames _ _ _ (var, Just x) = do
   when (x /= SubstitutedVal) $
     warn $ "ignoring non-name value for variable " <> fromVariable var
   return NullOutput
-formatNames _ _ _ (_, Nothing) = return NullOutput
 
 formatName :: CiteprocOutput a
            => NameFormat -> Formatting -> Int -> Name -> Eval a (Output a)

--- a/test/csl/name_LiteralShortFormAbbreviation.txt
+++ b/test/csl/name_LiteralShortFormAbbreviation.txt
@@ -1,0 +1,60 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+Arist.
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-05-04T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <names variable="author">
+        <name form="short"/>
+      </names>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+  {
+    "author": [
+      {
+        "literal": "Aristotle"
+      }
+    ],
+    "id": "ITEM-1",
+    "type": "classic"
+  }
+]
+<<===== INPUT =====<<
+
+
+>>===== ABBREVIATIONS =====>>
+{
+  "default": {
+    "author": {
+      "Aristotle": "Arist."
+    }
+  }
+}
+<<===== ABBREVIATIONS =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/test/csl/variables_CollectionTitleAbbreviation.txt
+++ b/test/csl/variables_CollectionTitleAbbreviation.txt
@@ -1,0 +1,54 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+OMT
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-05-04T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <text variable="collection-title" form="short"/>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+  {
+    "collection-title": "Oxford Medieval Texts",
+    "id": "ITEM-1",
+    "type": "book"
+  }
+]
+<<===== INPUT =====<<
+
+
+>>===== ABBREVIATIONS =====>>
+{
+  "default": {
+    "collection-title": {
+      "Oxford Medieval Texts": "OMT"
+    }
+  }
+}
+<<===== ABBREVIATIONS =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<

--- a/test/csl/variables_ContainerTitleAbbreviation.txt
+++ b/test/csl/variables_ContainerTitleAbbreviation.txt
@@ -1,0 +1,54 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+>>===== RESULT =====>>
+TRHS
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2026-05-04T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <text variable="container-title" form="short"/>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+  {
+    "container-title": "Transactions of the Royal Historical Society",
+    "id": "ITEM-1",
+    "type": "article-journal"
+  }
+]
+<<===== INPUT =====<<
+
+
+>>===== ABBREVIATIONS =====>>
+{
+  "default": {
+    "container-title": {
+      "Transactions of the Royal Historical Society": "TRHS"
+    }
+  }
+}
+<<===== ABBREVIATIONS =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
Add support for abbreviating literal names in names rendering with `form="short"`.